### PR TITLE
Expand documentation to be more newbie-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Takes primes as input to generate primodal .scl files.
 
 A unique primodal scale exists for every conceivable positive prime. *n*-primodality is the set of all rational numbers where the denominator is positive prime *n* and the integer numerator *a* is greater than or equal to *n*. Particularly of interest is the subset where n ≤ a < 8n, which always contains a [just fifth]. This is the range for which this program produces a [.scl file], a flexible format made by Manuel Op de Coul of the [Huygens-Fokker Foundation] for use with [Scala].
 
+Scala files are broadly but not universally supported by synthesizers and other computer music software. If you're interested in playing with these sounds, one prominent synthesizer with great .scl support is [Surge]. If you're interested in learning more about alternative tunings, a good place to start is the [Xenharmonic Wiki].
+
 This program is run via command line. It accepts primes greater than 2 that fit in an unsigned 32-bit integer. I've produced a portable linux binary which can be found in the builds directory. If you have any questions, feel free to file an issue!
 
 [Zheanna Erose]: https://www.youtube.com/channel/UC--VosYH0BHISbb4SFO9rQA
@@ -13,6 +15,8 @@ This program is run via command line. It accepts primes greater than 2 that fit 
 [.scl file]: https://huygens-fokker.org/scala/scl_format.html
 [Huygens-Fokker Foundation]: https://huygens-fokker.org/index_en.html
 [Scala]: https://www.huygens-fokker.org/scala/
+[Surge]: https://github.com/surge-synthesizer/surge
+[Xenharmonic Wiki]: https://en.xen.wiki
 
 ## Documentation:
 


### PR DESCRIPTION
Previously the documentation wasn't leaving much of a breadcrumb trail for folks who are unfamiliar with alternative tunings. This adds at least a couple of links. That should give folks a fighting chance.

This is mostly to test whether the CI exception for .md files works.

See #21